### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # stop
-stop(cash_out)
-dansta/lowred/magicclick
+stop (cash_out)
+usernames known -dansta/lowred/magicclick.and all usernames unknown to me but allocated as mine to stop betting
+im asking please that you stop all api bots appointed to me from placing any further bets on my behalf.
+setting up a github crypto wallet and for all balances of these bots to place there balance into this wallet.
+I would like the final balance.
+all details of how to effectively transfer final balance into my bank account safely.
+all keys/address or any other details also must be given to me of this crypto wallet.


### PR DESCRIPTION
# stop
stop(cash_out)
dansta/lowred/magicclick
stop (cash_out)
usernames known -dansta/lowred/magicclick.and all usernames unknown to me but allocated as mine to stop betting
im asking please that you stop all api bots appointed to me from placing any further bets on my behalf.
setting up a github crypto wallet and for all balances of these bots to place there balance into this wallet.
I would like the final balance.
all details of how to effectively transfer final balance into my bank account safely.
all keys/address or any other details also must be given to me of this crypto wallet.